### PR TITLE
fix material-icon dependency and add svg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1641,14 +1641,6 @@
         "chalk": "^4.0.0"
       }
     },
-    "@material-ui/icons": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.9.1.tgz",
-      "integrity": "sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==",
-      "requires": {
-        "@babel/runtime": "^7.4.4"
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@material-ui/icons": "^4.9.1",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/assets/icons/edit-icon.svg
+++ b/src/assets/icons/edit-icon.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="528.899px" height="528.899px" viewBox="0 0 528.899 528.899" style="enable-background:new 0 0 528.899 528.899;"
+	 xml:space="preserve">
+<g>
+	<path d="M328.883,89.125l107.59,107.589l-272.34,272.34L56.604,361.465L328.883,89.125z M518.113,63.177l-47.981-47.981
+		c-18.543-18.543-48.653-18.543-67.259,0l-45.961,45.961l107.59,107.59l53.611-53.611
+		C532.495,100.753,532.495,77.559,518.113,63.177z M0.3,512.69c-1.958,8.812,5.998,16.708,14.811,14.565l119.891-29.069
+		L27.473,390.597L0.3,512.69z"/>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+</svg>

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useContext } from 'react';
-import EditOutlinedIcon from '@material-ui/icons/EditOutlined';
 import { TasksContext } from '../TasksContext';
 import { createTask } from '../model/Task';
+import { ReactComponent as EditIcon } from '../assets/icons/edit-icon.svg';
 import './Card.css';
 
 const Card = ({task, stage, closeNewCardCallback}) => {
@@ -75,7 +75,7 @@ const Card = ({task, stage, closeNewCardCallback}) => {
           onClick={() => setEditing(true)}
         >
           <div className="card edit-icon">
-            {onHover && <EditOutlinedIcon fontSize="inherit"/>}
+            {onHover && <EditIcon style={{height: '12px', width: '12px'}}/>}
           </div>
           <div className="title">{taskTitle}</div>
         </div>


### PR DESCRIPTION
There was a dependency of `material-ui/icons` that was breaking build.
It is not necessary to use this dependency because of only 1 icon.